### PR TITLE
Feat more configs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,9 +165,13 @@ router.post(
 		// Build screenshot options
 		const screenshotOptions = {
 			type: body.format,
-			quality: body.quality,
 			fullPage: body.fullPage,
 		};
+
+		// Quality is only supported for JPEG and WebP formats
+		if (body.format === 'jpeg' || body.format === 'webp') {
+			screenshotOptions.quality = body.quality;
+		}
 
 		if (body.clip) {
 			screenshotOptions.clip = body.clip;

--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ router.post(
 		};
 
 		// Quality is only supported for JPEG and WebP formats
-		if (body.format === 'jpeg' || body.format === 'webp') {
+		if (body.format === "jpeg" || body.format === "webp") {
 			screenshotOptions.quality = body.quality;
 		}
 


### PR DESCRIPTION
Small fix to handle PNG and Quality conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quality settings for screenshots are now applied only to formats that support them (JPEG and WebP). PNG processing no longer receives ineffective quality parameters, improving consistency and efficiency of screenshot generation and preserving expected image output across formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->